### PR TITLE
Make bundler, rake, and rspec development dependencies

### DIFF
--- a/wappalyzer.gemspec
+++ b/wappalyzer.gemspec
@@ -13,15 +13,14 @@ Gem::Specification.new do |spec|
   spec.description   = %q{This analyzes a url and tries to guess what software it uses (like server software, CMS, framework, programming language).}
   spec.homepage      = "https://github.com/pulkit21/wappalyzer"
 
-
-
   spec.files         = `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(test|spec|features)/}) }
   spec.bindir        = "exe"
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "bundler", "~> 1.11"
-  spec.add_dependency "rake", "~> 10.0"
-  spec.add_dependency "rspec", "~> 3.0"
   spec.add_dependency "mini_racer", "~> 0.1.4"
+
+  spec.add_development_dependency "bundler", "~> 1.11"
+  spec.add_development_dependency "rake", "~> 10.0"
+  spec.add_development_dependency "rspec", "~> 3.0"
 end


### PR DESCRIPTION
@Shopify/plus-internal-dev 

This will prevent these dependencies from being included in bundles of apps that include this gem. For example, non-`rspec` apps shouldn't need `rspec` installed just for this gem.

From our app's repo:
```diff
 GIT
   remote: git@github.com:Shopify/wappalyzer
-  revision: fc005999e634faf5518eacdfec05206a1de4c9c7
+  revision: 31b9b73baa751051bc7c61a7a7cd785d101948e1
+  branch: less-dependencies
   specs:
     wappalyzer (0.1.0)
-      bundler (~> 1.11)
       mini_racer (~> 0.1.4)
-      rake (~> 10.0)
-      rspec (~> 3.0)
…
-    diff-lcs (1.2.5)
…
-    rspec (3.5.0)
-      rspec-core (~> 3.5.0)
-      rspec-expectations (~> 3.5.0)
-      rspec-mocks (~> 3.5.0)
-    rspec-core (3.5.4)
-      rspec-support (~> 3.5.0)
-    rspec-expectations (3.5.0)
-      diff-lcs (>= 1.2.0, < 2.0)
-      rspec-support (~> 3.5.0)
-    rspec-mocks (3.5.0)
-      diff-lcs (>= 1.2.0, < 2.0)
-      rspec-support (~> 3.5.0)
-    rspec-support (3.5.0)
```

http://bundler.io/rubygems.html